### PR TITLE
Retain c-strings, pointers to which are used by the OS's logger subsystem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oslog"
 description = "A minimal safe wrapper around Apple's Logging system"
 repository = "https://github.com/steven-joruk/oslog"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Steven Joruk <steven@joruk.com>"]
 edition = "2021"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,12 @@ impl From<log::Level> for Level {
 
 pub struct OsLog {
     inner: os_log_t,
+    /// These need to remain allocated or system logging code can use
+    /// them after they are freed.
+    #[allow(dead_code)]
+    subsystem: Option<CString>,
+    #[allow(dead_code)]
+    category: Option<CString>,
 }
 
 unsafe impl Send for OsLog {}
@@ -64,7 +70,11 @@ impl OsLog {
 
         assert!(!inner.is_null(), "Unexpected null value from os_log_create");
 
-        Self { inner }
+        Self {
+            inner,
+            subsystem: Some(subsystem),
+            category: Some(category),
+        }
     }
 
     #[inline]
@@ -73,7 +83,11 @@ impl OsLog {
 
         assert!(!inner.is_null(), "Unexpected null value for OS_DEFAULT_LOG");
 
-        Self { inner }
+        Self {
+            inner,
+            subsystem: None,
+            category: None,
+        }
     }
 
     #[inline]


### PR DESCRIPTION
Fixes #6 - CStrings used in constructor are passed as pointers to the OS's logging subsystem, which may (and evidently does) attempt to use them after they have been dropped.

The fix simply adds the CStrings as fields to the logger instance, so they are guaranteed to be retained for the lifetime of the logger.